### PR TITLE
Fix 'Address already in use' issue

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -283,6 +283,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Could not create socket epicly: %s\n", strerror(errno));
         exit(1);
     }
+    int option = 1;
+    setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &option, sizeof(option));
 
     struct sockaddr_in server_addr;
     memset(&server_addr, 0, sizeof(server_addr));


### PR DESCRIPTION
This PR is going to resolve the following issue:
```console
$ ./skedudle 6969
Schedule timezone: Asia/Novosibirsk
[INFO] Listening to http://127.0.0.1:6969/
^C
$ ./skedudle 6969
Schedule timezone: Asia/Novosibirsk
Could not bind socket epicly: Address already in use
```
To fix that we need to set `SO_REUSEADDR` option for socket